### PR TITLE
Move backup ZIP to /roms*/backup instead of tools directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,72 @@
-🎮 Session Recall for R36S
+### 🎮 Session Recall for R36S
+
 A Bash script to quickly relaunch saved games on your R36S system, integrating with RetroArch and RetroArch32.
 
-🚀 Features
-- Detects recent save files across multiple ROM directories.
-- Automatically identifies the system/console for each save.
-- Finds the correct ROM and core/emulator to launch.
-- Supports automatic (.state.auto) and manual (.state*) save states.
-- Launch the game from the save file 
+---
 
-🛠️ Installation
-Copy the Session_Recall script to roms/tools or to roms2/tools if you have 2 SD cards
+### 🚀 Features
 
-⚠️ Important Notes
-Testing: Only tested on emulators defined by default in RetroArch or RetroArch32. Compatibility with other setups is not guaranteed.
-Fixed.
+* Detects recent save files across multiple ROM directories.
+* Automatically identifies the system/console for each save.
+* Finds the correct ROM and core/emulator to launch.
+* Supports automatic (`.state.auto`) and manual (`.state*`) save states.
+* Launch a game directly from a save file.
+* **Backup all saves into a single ZIP archive** (SRM, SAV, STATE).
+* **Restore all saves from a ZIP backup** to their original locations.
 
-[MANE Constraint] 
-Resolved an issue preventing the backup process from being launched immediately.
-The core must now be fully loaded before the backup procedure can be executed.
+---
 
-Nintendo DS is not supported by this script since it relies on the Drastic core, which is currently incompatible.
+### 🛠️ Installation
 
-📄 License
+1. Copy the script to:
+
+   * `roms/tools/`
+   * or `roms2/tools/` if using two SD cards
+
+2. If a previous version exists:
+
+   * delete `Session Recall.sh`
+   * rename the new script to **`Session Recall.sh`**
+
+3. Launch the script from the Tools menu.
+
+---
+
+### 💾 Backup & Restore
+
+* Scroll to the bottom of the main menu.
+
+* Select **“Backup all saves zip”** to create a full backup.
+
+* The backup file is created in:
+
+  * `roms/backup/Session_Recall.zip`
+  * or `roms2/backup/Session_Recall.zip`
+
+* Use **“Restore all saves”** to extract the backup and overwrite existing saves.
+
+⚠️ Restoring will replace current save files with the versions from the ZIP.
+
+---
+
+### ⚠️ Important Notes
+
+* **Testing**: Tested on emulators defined by default in RetroArch or RetroArch32. Compatibility with other setups is not guaranteed.
+* **[MAME Constraint]**
+  Resolved an issue preventing the backup process from being launched immediately.
+  The core must now be fully loaded before the backup procedure can be executed.
+* **Nintendo DS is not supported**, as it relies on the Drastic core, which is currently incompatible.
+
+---
+
+### 📄 License
+
 MIT License – see License for details.
 
-# A coffee to offer?
-https://ko-fi.com/jason3x
+---
+
+### ☕ A coffee to offer?
+
+[https://ko-fi.com/jason3x](https://ko-fi.com/jason3x)
+
+---

--- a/Session_Recall.sh
+++ b/Session_Recall.sh
@@ -251,11 +251,11 @@ get_core_and_command() {
 backup_all_to_zip() {
     # On choisit le chemin de destination 
     local final_zip=""
-    if [ -d "/roms2/tools" ]; then final_zip="/roms2/tools/Session_Recall.zip"
-    elif [ -d "/roms/tools" ]; then final_zip="/roms/tools/Session_Recall.zip"
+    if [ -d "/roms2/backup" ]; then final_zip="/roms2/backup/Session_Recall.zip"
+    elif [ -d "/roms/backup" ]; then final_zip="/roms/backup/Session_Recall.zip"
     else
-        mkdir -p "/roms/tools"
-        final_zip="/roms/tools/Session_Recall.zip"
+        mkdir -p "/roms/backup"
+        final_zip="/roms/backup/Session_Recall.zip"
     fi
 
     dialog --backtitle "$BACKTITLE" --title "Backup ZIP" --infobox "\nScanning and compressing all saves...\nDestination: $final_zip\nPlease wait." 7 60 2>"$CURR_TTY"
@@ -281,7 +281,7 @@ backup_all_to_zip() {
 restore_all_from_zip() {
     local zip_found=""
     # On cherche où se trouve le fichier zip parmi les emplacements possibles
-    for path in "/roms/tools/Session_Recall.zip" "/roms2/tools/Session_Recall.zip"; do
+    for path in "/roms/backup/Session_Recall.zip" "/roms2/backup/Session_Recall.zip"; do
         if [ -f "$path" ]; then
             zip_found="$path"
             break
@@ -289,7 +289,7 @@ restore_all_from_zip() {
     done
 
     if [ -z "$zip_found" ]; then
-        show_dialog msgbox "Restore Error" "The file Session_Recall.zip was not found in:\n- /roms/tools/\n- /roms2/tools/"
+        show_dialog msgbox "Restore Error" "The file Session_Recall.zip was not found in:\n- /roms/backup/\n- /roms2/backup/"
         return
     fi
 


### PR DESCRIPTION
The backup ZIP was previously created in the tools directory (same location as the script),
which mixes data and tools.

This PR moves the backup destination to /roms/backup (or /roms2/backup),
which is more consistent with common folder layouts and existing backup usage.

Restore logic has been updated accordingly.
No functional behavior changed besides the destination path.

Edit : I tested the backup feature on real hardware (R36S Plus) and updated the README to document it.
Everything works perfectly. 👌
Feel free to use or adapt!